### PR TITLE
Prepare meroxa-py for publishing on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,23 @@
-# meroxa-py
+# Official Meroxa Python Client
 
-meroxa-py is an async-first library created to interact with the Meroxa platform-api
+This repo defines a Python wrapper around the Platform API. It provides functions for interacting with Connectors, Endpoints, Environments, Pipelines, Resources, and Resource Types.
 
-## Installation 
 
-`pip install /path/to/your/cloned/repo` 
+## Installing
 
-## Usage
+Install and update using [pip](https://pip.pypa.io/en/stable/getting-started/):
+
+```
+    $ pip install -U meroxa-py
+```
+
+
+## A Simple Example
 ```python
 import asyncio
 
 from meroxa import Meroxa
 from pprint import pprint
-
 
 auth="auth.token", 
 url="https://api.staging.meroxa.io"
@@ -20,7 +25,9 @@ url="https://api.staging.meroxa.io"
 async def main():
     async with Meroxa(auth=auth, api_route=url) as m:
         resp = await m.users.me()
-        pprint.pprint(resp)
+        pprint(resp)
 
 asyncio.run(main())
 ```
+
+To obtain a Meroxa Auth Token please see: [How to Obtain a Meroxa Access Token](https://docs.meroxa.com/guides/how-to-obtain-meroxa-access-token/)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
-# Official Meroxa Python Client
-
-This repo defines a Python wrapper around the Platform API. It provides functions for interacting with Connectors, Endpoints, Environments, Pipelines, Resources, and Resource Types.
-
+# Meroxa-py
 
 ## Installing
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,9 @@ packages = find:
 package_dir = = src
 include_package_data = True
 python_requires = >=3.7
-# Dependencies are in setup.py for GitHub's dependency graph.
+
+install_requires =
+    aiohttp
 
 [options.packages.find]
 where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,26 @@
+[metadata]
+name = meroxa-py
+version = 1.0.1
+url = https://meroxa.io/
+project_urls =
+    Source Code = https://github.com/meroxa/meroxa-py/
+    Issue Tracker = https://github.com/meroxa/meroxa-py/issues
+author = Eric Cheatham
+author_email = eric@meroxa.io
+description = Meroxa Platform API Python client
+long_description = file: README.md
+long_description_content_type = text/markdown
+classifiers =
+    Programming Language :: Python
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+
+[options]
+packages = find:
+package_dir = = src
+include_package_data = True
+python_requires = >=3.7
+# Dependencies are in setup.py for GitHub's dependency graph.
+
+[options.packages.find]
+where = src

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = meroxa-py
-version = 1.0.1
+version = 1.0.0
 url = https://meroxa.io/
 project_urls =
     Source Code = https://github.com/meroxa/meroxa-py/
@@ -10,6 +10,8 @@ author_email = eric@meroxa.io
 description = Meroxa Platform API Python client
 long_description = file: README.md
 long_description_content_type = text/markdown
+license = MIT
+license_files = LICENSE.md
 classifiers =
     Programming Language :: Python
     License :: OSI Approved :: MIT License

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-import setuptools
-
-# Metadata is in setup.cfg, this is for GitHub's dependency graph
-setuptools.setup(
-    name="meroxa-py",
-    install_requires=[
-        "aiohttp >= 3.8.1"
-    ],
-)

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,9 @@
 import setuptools
 
+# Metadata is in setup.cfg, this is for GitHub's dependency graph
 setuptools.setup(
     name="meroxa-py",
-    version="0.0.1",
-    author="Meroxa",
-    author_email="dev@meroxa.io",
-    url="https://github.com/meroxa/meroxa-py",
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
+    install_requires=[
+        "aiohttp >= 3.8.1"
     ],
-    package_dir={"": "src"},
-    packages=setuptools.find_packages(where="src"),
-    python_requires=">=3.6",
 )


### PR DESCRIPTION
Once this is merged we have two options:
1. Let Circle CI publish for us https://circleci.com/blog/publishing-a-python-package/
2. Publish from a developer computer

For the sake of simplicity, I would personally vote for having a dev push the initial version until we're happy with everything


Example of the project on the PyPI test package index: [meroxa-py](https://test.pypi.org/project/meroxa-py/)