### PR TITLE
[bug] Add Meroxa-Account-UUID to API Requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,8 @@ install: requirements.txt
 dev: requirements-dev.txt
 	pip install -r requirements-dev.txt
 
+install-hooks: dev
+	pre-commit install
+
 test:
 	tox

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 -r ./requirements.txt
 
-pre-commit
+pre-commit==2.20.0
 
 # unit testing reqs
 pytest==7.1.2

--- a/src/meroxa/__init__.py
+++ b/src/meroxa/__init__.py
@@ -19,7 +19,6 @@ from .resources import Resources
 from .resources import ResourcesResponse
 from .resources import ResourceSSHTunnel
 from .resources import UpdateResourceParams
-from .types import ClientOptions
 from .types import EnvironmentIdentifier
 from .types import ResourceType
 from .users import UserResponse
@@ -30,7 +29,6 @@ from .utils import ErrorResponse
 __all__ = [
     "Applications",
     "ApplicationResponse",
-    "ClientOptions",
     "ComplexEncoder",
     "Connectors",
     "ConnectorsResponse",

--- a/src/meroxa/applications.py
+++ b/src/meroxa/applications.py
@@ -16,11 +16,11 @@ class ApplicationResponse(MeroxaApiResponse):
         uuid: str,
         name: str,
         language: str,
-        git_sha: str,
         status: dict,
         pipeline: dict,
         created_at: str,
         updated_at: str,
+        git_sha: str = None,
         connectors: list[EntityIdentifier] = None,
         functions: list[EntityIdentifier] = None,
         resources: list[ApplicationResource] = None,
@@ -28,11 +28,11 @@ class ApplicationResponse(MeroxaApiResponse):
         self.uuid = uuid
         self.name = name
         self.language = language
-        self.git_sha = git_sha
         self.status = status
         self.pipeline = pipeline
         self.created_at = created_at
         self.updated_at = updated_at
+        self.git_sha = git_sha
         self.connectors = connectors
         self.functions = functions
         self.resources = resources

--- a/src/meroxa/client.py
+++ b/src/meroxa/client.py
@@ -14,7 +14,12 @@ class Meroxa:
     """Asynchronous Meroxa API handler"""
 
     def __init__(
-        self, auth, api_route=MEROXA_API_ROUTE, timeout=MEROXA_TIMEOUT, session=None
+        self,
+        auth,
+        api_route=MEROXA_API_ROUTE,
+        timeout=MEROXA_TIMEOUT,
+        session=None,
+        meroxa_account_uuid: str = None,
     ):
         """Create a session if one is not provided."""
 
@@ -23,7 +28,10 @@ class Meroxa:
         if session is None:
             session = aiohttp.ClientSession(
                 base_url=api_route,
-                headers={"Authorization": "Bearer {}".format(auth)},
+                headers={
+                    "Authorization": "Bearer {}".format(auth),
+                    "Meroxa-Account-UUID": meroxa_account_uuid,
+                },
                 timeout=aiohttp.ClientTimeout(timeout),
             )
 

--- a/src/meroxa/client.py
+++ b/src/meroxa/client.py
@@ -26,12 +26,16 @@ class Meroxa:
         if api_route is None:
             api_route = MEROXA_API_ROUTE
         if session is None:
+            headers = {
+                "Authorization": "Bearer {}".format(auth),
+            }
+
+            if meroxa_account_uuid:
+                headers.update({"Meroxa-Account-UUID": meroxa_account_uuid})
+
             session = aiohttp.ClientSession(
                 base_url=api_route,
-                headers={
-                    "Authorization": "Bearer {}".format(auth),
-                    "Meroxa-Account-UUID": meroxa_account_uuid,
-                },
+                headers=headers,
                 timeout=aiohttp.ClientTimeout(timeout),
             )
 

--- a/src/meroxa/types.py
+++ b/src/meroxa/types.py
@@ -23,13 +23,6 @@ class MeroxaApiResponse(object):
         ...
 
 
-class ClientOptions:
-    def __init__(self, auth: str, url: str, timeout=0.0):
-        self.auth = auth
-        self.timeout = timeout
-        self.url = url
-
-
 class EnvironmentIdentifier:
     def __init__(self, name=None, uuid=None):
         self.name = name


### PR DESCRIPTION
Part of https://github.com/meroxa/turbine-project/issues/277

Meroxa-py client now requires `meroxa_account_uuid` which will then be set as a header value for  `Meroxa-Acconut-UUID` 