### PR TITLE
fix: JSON parsing of collection create responses

### DIFF
--- a/src/meroxa/connectors.py
+++ b/src/meroxa/connectors.py
@@ -26,6 +26,7 @@ class ConnectorsResponse(MeroxaApiResponse):
         type: str,
         updated_at: str,
         uuid: str,
+        collection: str,
         trace: str = None,
         environment: EntityIdentifier = None,
     ) -> None:
@@ -43,6 +44,7 @@ class ConnectorsResponse(MeroxaApiResponse):
         self.type = type
         self.updated_at = updated_at
         self.uuid = uuid
+        self.collection = collection
         self.trace = trace
         self.environment = environment
         super().__init__()

--- a/tests/test_connectors.py
+++ b/tests/test_connectors.py
@@ -23,6 +23,7 @@ CONNECTOR_JSON = {
     "metadata": {"mx:connectorType": "source"},
     "created_at": "2022-04-20T22:20:38Z",
     "updated_at": "2022-04-20T22:20:38Z",
+    "collection": "example_collection",
 }
 
 ERROR_MESSAGE = {"code": "not_found", "message": "could not find function"}


### PR DESCRIPTION
Attempting to parse the JSON Collection create responses were failed due to a missing field in the object we were parsing into


Before:  
```bash
$  m apps rm meroxa-app-create-test --yolo && m apps deploy
Removing application "meroxa-app-create-test"...
Application "meroxa-app-create-test" successfully removed
Validating your app.json...
	✔ Checked your language is "python"
	✔ Checked your application name is "meroxa-app-create-test"
Checking for uncommitted changes...
	✔ No uncommitted changes!
Preparing to deploy application "meroxa-app-create-test"...
	✔ Application built
	✔ Can access your Turbine resources
	✔ No need to create process image
Deploying application "meroxa-app-create-test"...

Fetching resource named 'pg'
Checking if pipeline exists for application: meroxa-app-create-test
No pipeline found, creating a new pipeline: turbine-pipeline-meroxa-app-create-test
Creating SOURCE connector from resource: pg

Error: __init__() got an unexpected keyword argument 'id'

```

After

```bash
m apps rm meroxa-app-create-test --yolo && m apps deploy
Removing application "meroxa-app-create-test"...
Application "meroxa-app-create-test" successfully removed
Validating your app.json...
	✔ Checked your language is "python"
	✔ Checked your application name is "meroxa-app-create-test"
Checking for uncommitted changes...
	✔ No uncommitted changes!
Preparing to deploy application "meroxa-app-create-test"...
	✔ Application built
	✔ Can access your Turbine resources
	✔ No need to create process image
Deploying application "meroxa-app-create-test"...
	✔ Application "meroxa-app-create-test" successfully deployed!

  ✨ To visualize your application, visit https://dashboard.meroxa.io/apps/meroxa-app-create-test/detail
```