### PR TITLE
fix: setup.cfg file typo

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ where = src
 
 [semantic_release]
 version_variable = src/meroxa/__init__.py:__version__
-version_source = tags
+version_source = tag
 branch = main
 changelog_file = CHANGELOG.md
 # let semantic release manage PyPI uploads


### PR DESCRIPTION
`tags` -> `tag` 

as per https://python-semantic-release.readthedocs.io/en/latest/configuration.html#config-version-source