### PR TITLE
fix: update response object

### DIFF
--- a/src/meroxa/__init__.py
+++ b/src/meroxa/__init__.py
@@ -60,4 +60,4 @@ __all__ = [
 """
 Semantic release checks and updates version variable
 """
-__version__ = "1.2.0"
+__version__ = "1.3.0"

--- a/src/meroxa/functions.py
+++ b/src/meroxa/functions.py
@@ -21,6 +21,8 @@ class FunctionResponse(MeroxaApiResponse):
         env_vars: dict[str, str],
         status: dict,
         pipeline: dict,
+        created_at: str,
+        updated_at: str,
     ) -> None:
         self.uuid = uuid
         self.name = name
@@ -32,6 +34,8 @@ class FunctionResponse(MeroxaApiResponse):
         self.env_vars = env_vars
         self.status = status
         self.pipeline = pipeline
+        self.created_at = created_at
+        self.updated_at = updated_at
         super().__init__()
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -20,6 +20,8 @@ FUNCTION_JSON = {
     "env_vars": {},
     "status": {"state": "pending", "details": ""},
     "pipeline": {"name": "default"},
+    "created_at": "2022-03-02T20:18:14Z",
+    "updated_at": "2022-03-02T20:18:14Z",
 }
 
 ERROR_MESSAGE = {"code": "not_found", "message": "could not find function"}
@@ -32,6 +34,8 @@ def assert_function_equality(response, comparison):
     assert response.image == comparison.get("image")
     assert response.env_vars == comparison.get("env_vars")
     assert response.pipeline == comparison.get("pipeline")
+    assert response.created_at == comparison.get("created_at")
+    assert response.updated_at == comparison.get("updated_at")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### What happened
The response object for functions is now returning updated/created at times. The JSON unpack library was unable to deserialize the API response properly and threw an error.

### How to react to this
Need to update Meroxa-py to response agnostic. That may lose us the known shape of the response but we don't have to keep doing this. 