### PR TITLE
v1.3.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,8 @@ where = src
 
 [semantic_release]
 version_variable = src/meroxa/__init__.py:__version__
-version_source = tag
+# derive version from commits now that they are normalized.
+version_source = commit
 branch = main
 changelog_file = CHANGELOG.md
 # let semantic release manage PyPI uploads

--- a/src/meroxa/__init__.py
+++ b/src/meroxa/__init__.py
@@ -60,4 +60,4 @@ __all__ = [
 """
 Semantic release checks and updates version variable
 """
-__version__ = "1.3.0"
+__version__ = "1.3.1"


### PR DESCRIPTION
Normalize tagging in this repo. Semantic release depends on tagging or commits to determine the next version. For reasons, if you don't use commits it won't create a commit to update the version variable. That leads to the situation where the most recent tag and the actual value of the version variable get out of sync. 