### PR TITLE
feat: Refactor Meroxa-py to handle API Changes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include VERSION.txt

--- a/src/meroxa/__init__.py
+++ b/src/meroxa/__init__.py
@@ -1,58 +1,42 @@
-from .applications import ApplicationResponse
 from .applications import Applications
 from .applications import CreateApplicationParams
 from .client import Meroxa
 from .connectors import Connectors
-from .connectors import ConnectorsResponse
 from .connectors import CreateConnectorParams
 from .connectors import UpdateConnectorParams
 from .functions import CreateFunctionParams
-from .functions import FunctionResponse
 from .functions import Functions
 from .pipelines import CreatePipelineParams
 from .pipelines import PipelineIdentifiers
-from .pipelines import PipelineResponse
 from .pipelines import UpdatePipelineParams
 from .resources import CreateResourceParams
 from .resources import ResourceCredentials
 from .resources import Resources
-from .resources import ResourcesResponse
 from .resources import ResourceSSHTunnel
 from .resources import UpdateResourceParams
 from .types import EnvironmentIdentifier
 from .types import ResourceType
-from .users import UserResponse
 from .users import Users
-from .utils import ComplexEncoder
-from .utils import ErrorResponse
 
 __all__ = [
     "Applications",
-    "ApplicationResponse",
-    "ComplexEncoder",
     "Connectors",
-    "ConnectorsResponse",
     "CreateApplicationParams",
     "CreateConnectorParams",
     "CreateFunctionParams",
     "CreatePipelineParams",
     "CreateResourceParams",
     "EnvironmentIdentifier",
-    "ErrorResponse",
-    "FunctionResponse",
     "Functions",
     "Meroxa",
     "PipelineIdentifiers",
-    "PipelineResponse",
     "ResourceCredentials",
     "Resources",
-    "ResourcesResponse",
     "ResourceSSHTunnel",
     "ResourceType",
     "UpdateConnectorParams",
     "UpdatePipelineParams",
     "UpdateResourceParams",
-    "UserResponse",
     "Users",
 ]
 

--- a/src/meroxa/__init__.py
+++ b/src/meroxa/__init__.py
@@ -15,6 +15,7 @@ from .resources import Resources
 from .resources import ResourceSSHTunnel
 from .resources import UpdateResourceParams
 from .types import EnvironmentIdentifier
+from .types import ResourceType
 from .users import Users
 
 __all__ = [
@@ -30,6 +31,7 @@ __all__ = [
     "Meroxa",
     "PipelineIdentifiers",
     "ResourceCredentials",
+    "ResourceType",
     "Resources",
     "ResourceSSHTunnel",
     "UpdateConnectorParams",

--- a/src/meroxa/__init__.py
+++ b/src/meroxa/__init__.py
@@ -15,7 +15,6 @@ from .resources import Resources
 from .resources import ResourceSSHTunnel
 from .resources import UpdateResourceParams
 from .types import EnvironmentIdentifier
-from .types import ResourceType
 from .users import Users
 
 __all__ = [
@@ -33,7 +32,6 @@ __all__ = [
     "ResourceCredentials",
     "Resources",
     "ResourceSSHTunnel",
-    "ResourceType",
     "UpdateConnectorParams",
     "UpdatePipelineParams",
     "UpdateResourceParams",

--- a/src/meroxa/applications.py
+++ b/src/meroxa/applications.py
@@ -1,41 +1,12 @@
 import json
 
+from aiohttp import ClientSession
+
 from .pipelines import PipelineIdentifiers
-from .types import ApplicationResource
-from .types import EntityIdentifier
-from .types import MeroxaApiResponse
 from .utils import ComplexEncoder
 
+
 APPLICATIONS_BASE_PATH = "/v1/applications"
-
-
-class ApplicationResponse(MeroxaApiResponse):
-    def __init__(
-        self,
-        uuid: str,
-        name: str,
-        language: str,
-        status: dict,
-        pipeline: dict,
-        created_at: str,
-        updated_at: str,
-        git_sha: str = None,
-        connectors: list[EntityIdentifier] = None,
-        functions: list[EntityIdentifier] = None,
-        resources: list[ApplicationResource] = None,
-    ) -> None:
-        self.uuid = uuid
-        self.name = name
-        self.language = language
-        self.status = status
-        self.pipeline = pipeline
-        self.created_at = created_at
-        self.updated_at = updated_at
-        self.git_sha = git_sha
-        self.connectors = connectors
-        self.functions = functions
-        self.resources = resources
-        super().__init__()
 
 
 class CreateApplicationParams:
@@ -61,27 +32,24 @@ class CreateApplicationParams:
 
 
 class Applications:
-    def __init__(self, session) -> None:
+    def __init__(self, session: ClientSession) -> None:
         self._session = session
 
     async def get(self, name_or_uuid: str):
         async with self._session.get(
             APPLICATIONS_BASE_PATH + "/{}".format(name_or_uuid)
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def list(self):
         async with self._session.get(APPLICATIONS_BASE_PATH) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def delete(self, name_or_uuid: str):
         async with self._session.delete(
             APPLICATIONS_BASE_PATH + "/{}".format(name_or_uuid)
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def create(self, create_application_parameters: CreateApplicationParams):
         async with self._session.post(
@@ -90,5 +58,4 @@ class Applications:
                 create_application_parameters.repr_json(), cls=ComplexEncoder
             ),
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()

--- a/src/meroxa/applications.py
+++ b/src/meroxa/applications.py
@@ -4,7 +4,6 @@ from .pipelines import PipelineIdentifiers
 from .types import ApplicationResource
 from .types import EntityIdentifier
 from .types import MeroxaApiResponse
-from .utils import api_response
 from .utils import ComplexEncoder
 
 APPLICATIONS_BASE_PATH = "/v1/applications"
@@ -65,27 +64,25 @@ class Applications:
     def __init__(self, session) -> None:
         self._session = session
 
-    @api_response(ApplicationResponse)
     async def get(self, name_or_uuid: str):
-
         async with self._session.get(
             APPLICATIONS_BASE_PATH + "/{}".format(name_or_uuid)
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(ApplicationResponse)
     async def list(self):
-
         async with self._session.get(APPLICATIONS_BASE_PATH) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
     async def delete(self, name_or_uuid: str):
         async with self._session.delete(
             APPLICATIONS_BASE_PATH + "/{}".format(name_or_uuid)
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(ApplicationResponse)
     async def create(self, create_application_parameters: CreateApplicationParams):
         async with self._session.post(
             APPLICATIONS_BASE_PATH,
@@ -93,4 +90,5 @@ class Applications:
                 create_application_parameters.repr_json(), cls=ComplexEncoder
             ),
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)

--- a/src/meroxa/connectors.py
+++ b/src/meroxa/connectors.py
@@ -1,54 +1,11 @@
 import json
 from typing import Any
 
-from .types import EntityIdentifier
-from .types import MeroxaApiResponse
+from aiohttp import ClientSession
+
 from .utils import ComplexEncoder
 
 CONNECTORS_BASE_PATH = "/v1/connectors"
-
-
-class ConnectorsResponse(MeroxaApiResponse):
-    def __init__(
-        self,
-        id: str,
-        config: dict[str, str],
-        created_at: str,
-        metadata: dict[str, str],
-        name: str,
-        resource_name: str,
-        pipeline_name: str,
-        resource_id: str,
-        resource_uuid: str,
-        pipeline_id: str,
-        streams: dict[str, str],
-        state: str,
-        type: str,
-        updated_at: str,
-        uuid: str,
-        collection: str,
-        trace: str = None,
-        environment: EntityIdentifier = None,
-    ) -> None:
-        self.id = id
-        self.config = config
-        self.created_at = created_at
-        self.metadata = metadata
-        self.name = name
-        self.resource_name = resource_name
-        self.pipeline_name = pipeline_name
-        self.resource_id = resource_id
-        self.resource_uuid = resource_id
-        self.pipeline_id = pipeline_id
-        self.streams = streams
-        self.state = state
-        self.type = type
-        self.updated_at = updated_at
-        self.uuid = uuid
-        self.collection = collection
-        self.trace = trace
-        self.environment = environment
-        super().__init__()
 
 
 class CreateConnectorParams:
@@ -99,27 +56,24 @@ class UpdateConnectorParams:
 
 
 class Connectors:
-    def __init__(self, session) -> None:
+    def __init__(self, session: ClientSession) -> None:
         self._session = session
 
     async def get(self, name_or_id: str):
         async with self._session.get(
             CONNECTORS_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def list(self):
         async with self._session.get(CONNECTORS_BASE_PATH) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def delete(self, name_or_id: str):
         async with self._session.delete(
             CONNECTORS_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def create(self, create_connector_parameters: CreateConnectorParams):
         async with self._session.post(
@@ -128,8 +82,7 @@ class Connectors:
                 create_connector_parameters.repr_json(), cls=ComplexEncoder
             ),
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def update(
         self, name_or_id: str, update_connector_parameters: UpdateConnectorParams
@@ -140,5 +93,4 @@ class Connectors:
                 update_connector_parameters.repr_json(), cls=ComplexEncoder
             ),
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()

--- a/src/meroxa/connectors.py
+++ b/src/meroxa/connectors.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from .types import EntityIdentifier
 from .types import MeroxaApiResponse
-from .utils import api_response
 from .utils import ComplexEncoder
 
 CONNECTORS_BASE_PATH = "/v1/connectors"
@@ -103,25 +102,25 @@ class Connectors:
     def __init__(self, session) -> None:
         self._session = session
 
-    @api_response(ConnectorsResponse)
     async def get(self, name_or_id: str):
         async with self._session.get(
             CONNECTORS_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(ConnectorsResponse)
     async def list(self):
         async with self._session.get(CONNECTORS_BASE_PATH) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
     async def delete(self, name_or_id: str):
         async with self._session.delete(
             CONNECTORS_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(ConnectorsResponse)
     async def create(self, create_connector_parameters: CreateConnectorParams):
         async with self._session.post(
             CONNECTORS_BASE_PATH,
@@ -129,9 +128,9 @@ class Connectors:
                 create_connector_parameters.repr_json(), cls=ComplexEncoder
             ),
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(ConnectorsResponse)
     async def update(
         self, name_or_id: str, update_connector_parameters: UpdateConnectorParams
     ):
@@ -141,4 +140,5 @@ class Connectors:
                 update_connector_parameters.repr_json(), cls=ComplexEncoder
             ),
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)

--- a/src/meroxa/functions.py
+++ b/src/meroxa/functions.py
@@ -2,7 +2,6 @@ import json
 
 from .pipelines import PipelineIdentifiers
 from .types import MeroxaApiResponse
-from .utils import api_response
 from .utils import ComplexEncoder
 
 FUNCTIONS_BASE_PATH = "/v1/functions"
@@ -77,14 +76,13 @@ class Functions:
     def __init__(self, session) -> None:
         self._session = session
 
-    @api_response(FunctionResponse)
     async def get(self, name_or_id: str):
         async with self._session.get(
             FUNCTIONS_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(FunctionResponse)
     async def list(self):
         async with self._session.get(FUNCTIONS_BASE_PATH) as resp:
             return await resp.text()
@@ -93,12 +91,13 @@ class Functions:
         async with self._session.delete(
             FUNCTIONS_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(FunctionResponse)
     async def create(self, create_function_parameters: CreateFunctionParams):
         async with self._session.post(
             FUNCTIONS_BASE_PATH,
             data=json.dumps(create_function_parameters.repr_json(), cls=ComplexEncoder),
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)

--- a/src/meroxa/functions.py
+++ b/src/meroxa/functions.py
@@ -1,41 +1,11 @@
 import json
 
+from aiohttp import ClientSession
+
 from .pipelines import PipelineIdentifiers
-from .types import MeroxaApiResponse
 from .utils import ComplexEncoder
 
 FUNCTIONS_BASE_PATH = "/v1/functions"
-
-
-class FunctionResponse(MeroxaApiResponse):
-    def __init__(
-        self,
-        uuid: str,
-        name: str,
-        input_stream: str,
-        output_stream: str,
-        image: str,
-        command: list[str],
-        args: list[str],
-        env_vars: dict[str, str],
-        status: dict,
-        pipeline: dict,
-        created_at: str,
-        updated_at: str,
-    ) -> None:
-        self.uuid = uuid
-        self.name = name
-        self.input_stream = input_stream
-        self.output_stream = output_stream
-        self.image = image
-        self.command = command
-        self.args = args
-        self.env_vars = env_vars
-        self.status = status
-        self.pipeline = pipeline
-        self.created_at = created_at
-        self.updated_at = updated_at
-        super().__init__()
 
 
 class CreateFunctionParams:
@@ -73,32 +43,28 @@ class CreateFunctionParams:
 
 
 class Functions:
-    def __init__(self, session) -> None:
+    def __init__(self, session: ClientSession) -> None:
         self._session = session
 
     async def get(self, name_or_id: str):
         async with self._session.get(
             FUNCTIONS_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def list(self):
         async with self._session.get(FUNCTIONS_BASE_PATH) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def delete(self, name_or_id: str):
         async with self._session.delete(
             FUNCTIONS_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def create(self, create_function_parameters: CreateFunctionParams):
         async with self._session.post(
             FUNCTIONS_BASE_PATH,
             data=json.dumps(create_function_parameters.repr_json(), cls=ComplexEncoder),
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()

--- a/src/meroxa/functions.py
+++ b/src/meroxa/functions.py
@@ -85,7 +85,8 @@ class Functions:
 
     async def list(self):
         async with self._session.get(FUNCTIONS_BASE_PATH) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
     async def delete(self, name_or_id: str):
         async with self._session.delete(

--- a/src/meroxa/pipelines.py
+++ b/src/meroxa/pipelines.py
@@ -2,7 +2,6 @@ import json
 
 from .types import EnvironmentIdentifier
 from .types import MeroxaApiResponse
-from .utils import api_response
 from .utils import ComplexEncoder
 
 PIPELINE_BASE_PATH = "/v1/pipelines"
@@ -93,33 +92,33 @@ class Pipelines:
     def __init__(self, session) -> None:
         self._session = session
 
-    @api_response(PipelineResponse)
     async def get(self, name_or_id: str):
         async with self._session.get(
             PIPELINE_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(PipelineResponse)
     async def list(self):
         async with self._session.get(PIPELINE_BASE_PATH) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
     async def delete(self, name_or_id: str):
         async with self._session.delete(
             PIPELINE_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(PipelineResponse)
     async def create(self, create_pipeline_parameters: CreatePipelineParams):
         async with self._session.post(
             PIPELINE_BASE_PATH,
             data=json.dumps(create_pipeline_parameters.repr_json(), cls=ComplexEncoder),
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(PipelineResponse)
     async def update(
         self, pipeline_name_or_id: str, update_pipeline_parameters: UpdatePipelineParams
     ):
@@ -127,4 +126,5 @@ class Pipelines:
             PIPELINE_BASE_PATH + "/{}".format(pipeline_name_or_id),
             json=json.dumps(update_pipeline_parameters.repr_json(), cls=ComplexEncoder),
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)

--- a/src/meroxa/pipelines.py
+++ b/src/meroxa/pipelines.py
@@ -1,36 +1,11 @@
 import json
 
+from aiohttp import ClientSession
+
 from .types import EnvironmentIdentifier
-from .types import MeroxaApiResponse
 from .utils import ComplexEncoder
 
 PIPELINE_BASE_PATH = "/v1/pipelines"
-
-
-class PipelineResponse(MeroxaApiResponse):
-    def __init__(
-        self,
-        uuid: str,
-        account_id: int,
-        project_id: int,
-        name: str,
-        state: str,
-        created_at: str,
-        updated_at: str,
-        environment: EnvironmentIdentifier = None,
-        metadata: dict[str, str] = None,
-        **kwargs
-    ) -> None:
-        self.created_at = created_at
-        self.uuid = uuid
-        self.account_id = account_id
-        self.project_id = project_id
-        self.name = name
-        self.state = state
-        self.updated_at = updated_at
-        self.environment = environment
-        self.metadata = metadata
-        super().__init__()
 
 
 class CreatePipelineParams:
@@ -89,35 +64,31 @@ class PipelineIdentifiers:
 
 
 class Pipelines:
-    def __init__(self, session) -> None:
+    def __init__(self, session: ClientSession) -> None:
         self._session = session
 
     async def get(self, name_or_id: str):
         async with self._session.get(
             PIPELINE_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def list(self):
         async with self._session.get(PIPELINE_BASE_PATH) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def delete(self, name_or_id: str):
         async with self._session.delete(
             PIPELINE_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def create(self, create_pipeline_parameters: CreatePipelineParams):
         async with self._session.post(
             PIPELINE_BASE_PATH,
             data=json.dumps(create_pipeline_parameters.repr_json(), cls=ComplexEncoder),
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()
 
     async def update(
         self, pipeline_name_or_id: str, update_pipeline_parameters: UpdatePipelineParams
@@ -126,5 +97,4 @@ class Pipelines:
             PIPELINE_BASE_PATH + "/{}".format(pipeline_name_or_id),
             json=json.dumps(update_pipeline_parameters.repr_json(), cls=ComplexEncoder),
         ) as resp:
-            res = await resp.text()
-            return json.loads(res)
+            return await resp.json()

--- a/src/meroxa/resources.py
+++ b/src/meroxa/resources.py
@@ -3,7 +3,6 @@ from typing import Any
 
 from .types import EnvironmentIdentifier
 from .types import MeroxaApiResponse
-from .utils import api_response
 from .utils import ComplexEncoder
 
 RESOURCE_BASE_PATH = "/v1/resources"
@@ -144,33 +143,33 @@ class Resources:
     def __init__(self, session) -> None:
         self._session = session
 
-    @api_response(ResourcesResponse)
     async def get(self, name_or_id: str):
         async with self._session.get(
             RESOURCE_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(ResourcesResponse)
     async def list(self):
         async with self._session.get(RESOURCE_BASE_PATH) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
     async def delete(self, name_or_id: str):
         async with self._session.delete(
             RESOURCE_BASE_PATH + "/{}".format(name_or_id)
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(ResourcesResponse)
     async def create(self, create_resource_parameters: CreateResourceParams):
         async with self._session.post(
             RESOURCE_BASE_PATH,
             data=json.dumps(create_resource_parameters.repr_json(), cls=ComplexEncoder),
         ) as resp:
-            return await resp.text()
+            res = await resp.text()
+            return json.loads(res)
 
-    @api_response(ResourcesResponse)
     async def update(
         self, name_or_id: str, update_resource_parameters: UpdateResourceParams
     ):
@@ -179,4 +178,4 @@ class Resources:
             json=json.dumps(update_resource_parameters.repr_json(), cls=ComplexEncoder),
         ) as resp:
             res = await resp.text()
-            return ResourcesResponse(**json.loads(res))
+            return json.loads(res)

--- a/src/meroxa/types.py
+++ b/src/meroxa/types.py
@@ -1,21 +1,4 @@
-from enum import Enum
 from typing import Any
-
-
-class ResourceType(Enum):
-    POSTGRES = "postgres"
-    MYSQL = "mysql"
-    REDSHIFT = "redshift"
-    URL = "url"
-    S3 = "s3"
-    MONGODB = "mongodb"
-    ELASTICSEARCH = "elasticsearch"
-    SNOWFLAKE = "snowflakedb"
-    BIGQUERY = "bigquery"
-    SQLSERVER = "sqlserver"
-    COSMODB = "cosmodb"
-    KAFKA = "kafka"
-    CONFLUENTCLOUD = "confluentcloud"
 
 
 class MeroxaApiResponse(object):
@@ -70,9 +53,9 @@ class ResourceNode:
         res = {}
 
         if self.connectors:
-            res.update(self.connectors)
+            res.update({"connectors": self.connectors})
 
         if self.functions:
-            res.update(self.functions)
+            res.update({"functions": self.functions})
 
         return res

--- a/src/meroxa/types.py
+++ b/src/meroxa/types.py
@@ -17,7 +17,6 @@ class EnvironmentIdentifier:
 
 class ResourceCollection:
     def __init__(self, name=None, destination=None, source=None):
-
         self.name = name
         self.source = source
         self.destination = destination
@@ -25,7 +24,6 @@ class ResourceCollection:
 
 class ApplicationResource:
     def __init__(self, name=None, uuid=None, collection: Any = None):
-
         self.name = name
         self.uuid = uuid
         self.collection = ResourceCollection(**collection)

--- a/src/meroxa/types.py
+++ b/src/meroxa/types.py
@@ -1,4 +1,21 @@
+from enum import Enum
 from typing import Any
+
+
+class ResourceType(Enum):
+    POSTGRES = "postgres"
+    MYSQL = "mysql"
+    REDSHIFT = "redshift"
+    URL = "url"
+    S3 = "s3"
+    MONGODB = "mongodb"
+    ELASTICSEARCH = "elasticsearch"
+    SNOWFLAKE = "snowflakedb"
+    BIGQUERY = "bigquery"
+    SQLSERVER = "sqlserver"
+    COSMODB = "cosmodb"
+    KAFKA = "kafka"
+    CONFLUENTCLOUD = "confluentcloud"
 
 
 class MeroxaApiResponse(object):

--- a/src/meroxa/users.py
+++ b/src/meroxa/users.py
@@ -1,41 +1,13 @@
-import json
-
-from .types import MeroxaApiResponse
-
-
-class UserResponse(MeroxaApiResponse):
-    def __init__(
-        self,
-        uuid: str,
-        email: str,
-        given_name: str,
-        family_name: str,
-        email_verified: bool,
-        picture: str,
-        last_login: str,
-        features: list[str],
-        username=None,
-    ) -> None:
-        self.uuid = uuid
-        self.email = email
-        self.given_name = given_name
-        self.family_name = family_name
-        self.email_verified = email_verified
-        self.picture = picture
-        self.last_login = last_login
-        self.features = features
-        self.username = username
-        super().__init__()
+from aiohttp import ClientSession
 
 
 class Users:
-    def __init__(self, session) -> None:
+    def __init__(self, session: ClientSession) -> None:
         self._session = session
 
     async def me(self):
         try:
             async with self._session.get("/v1/users/me") as resp:
-                res = await resp.text()
-                return json.loads(res)
+                return await resp.json()
         except Exception as e:
             raise e

--- a/src/meroxa/users.py
+++ b/src/meroxa/users.py
@@ -1,5 +1,6 @@
+import json
+
 from .types import MeroxaApiResponse
-from .utils import api_response
 
 
 class UserResponse(MeroxaApiResponse):
@@ -31,7 +32,10 @@ class Users:
     def __init__(self, session) -> None:
         self._session = session
 
-    @api_response(UserResponse)
     async def me(self):
-        async with self._session.get("/v1/users/me") as resp:
-            return await resp.text()
+        try:
+            async with self._session.get("/v1/users/me") as resp:
+                res = await resp.text()
+                return json.loads(res)
+        except Exception as e:
+            raise e

--- a/src/meroxa/utils.py
+++ b/src/meroxa/utils.py
@@ -1,8 +1,4 @@
 import json
-from json import JSONDecodeError
-from typing import Type
-
-from .types import MeroxaApiResponse
 
 
 class ComplexEncoder(json.JSONEncoder):
@@ -11,48 +7,3 @@ class ComplexEncoder(json.JSONEncoder):
             return obj.repr_json()
         else:
             return json.JSONEncoder.default(self, obj)
-
-
-class ErrorResponse(object):
-    def __init__(self, code: str, message: str, details=None) -> None:
-        self.code = code
-        self.message = message
-        self.details = details
-
-    def __repr__(self):
-        details = ""
-        if self.details and len(self.details) > 0:
-            details = f"; {len(self.details)} detail(s) provided\n"
-            count = 1
-            for i in self.details:
-                joined = ". ".join(self.details[i])
-                iter = f"{count}. {i}: {joined}\n"
-                details = details + iter
-                count += 1
-
-        return f"{self.message} {details}"
-
-
-def parse_error_message(error):
-    try:
-        return ErrorResponse(**json.loads(error))
-    except JSONDecodeError or TypeError:
-        split = error.split("\n", 1)
-        return ErrorResponse("Error", split[0])
-
-
-def api_response(return_type: Type[MeroxaApiResponse]):
-    def inner(func):
-        async def wrapper(*args, **kwargs):
-            res = await func(*args, **kwargs)
-            try:
-                parsed = json.loads(res)
-                if isinstance(parsed, list):
-                    return None, [return_type(**par) for par in parsed]
-                return None, return_type(**json.loads(res))
-            except (JSONDecodeError, TypeError):
-                return parse_error_message(res), None
-
-        return wrapper
-
-    return inner

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+def assert_response_eq(response, comparison):
+    assert sorted(response.items()) == sorted(comparison.items())

--- a/tests/test_applications.py
+++ b/tests/test_applications.py
@@ -2,6 +2,7 @@ import json
 from unittest.mock import patch
 
 import pytest
+from tests import assert_response_eq
 
 from meroxa import Applications
 from meroxa import CreateApplicationParams
@@ -24,15 +25,10 @@ APP_JSON = {
 ERROR_MESSAGE = {"code": "not_found", "message": "could not find application"}
 
 
-# All test coroutines will be treated as marked.
-def assert_response_eq(response, comparison):
-    assert sorted(response.items()) == sorted(comparison.items())
-
-
 @pytest.mark.asyncio
 @patch("aiohttp.ClientSession")
 async def test_application_get_success(mock_session):
-    mock_session.get.return_value.__aenter__.return_value.text.return_value = (
+    mock_session.get.return_value.__aenter__.return_value.json.return_value = (
         json.dumps(APP_JSON)
     )
     mock_session.get.return_value.__aenter__.return_value.status = 200
@@ -41,32 +37,33 @@ async def test_application_get_success(mock_session):
 
     assert mock_session.get.call_count == 1
 
-    assert_response_eq(apps_response, APP_JSON)
+    assert_response_eq(json.loads(apps_response), APP_JSON)
 
 
 @pytest.mark.asyncio
 @patch("aiohttp.ClientSession")
 async def test_applications_list_success(mock_session):
-    mock_session.get.return_value.__aenter__.return_value.text.return_value = (
+    mock_session.get.return_value.__aenter__.return_value.json.return_value = (
         json.dumps([APP_JSON, APP_JSON])
     )
     mock_session.get.return_value.__aenter__.return_value.status = 200
 
-    resource_response = await Applications(mock_session).list()
+    response = await Applications(mock_session).list()
+    json_resp = json.loads(response)
 
     assert mock_session.get.call_count == 1
 
-    assert isinstance(resource_response, list)
-    assert len(resource_response) == 2
+    assert isinstance(response, str)
+    assert len(json_resp) == 2
 
-    assert_response_eq(resource_response[0], APP_JSON)
-    assert_response_eq(resource_response[1], APP_JSON)
+    assert_response_eq(json_resp[0], APP_JSON)
+    assert_response_eq(json_resp[1], APP_JSON)
 
 
 @pytest.mark.asyncio
 @patch("aiohttp.ClientSession")
 async def test_applications_delete_success(mock_session):
-    mock_session.delete.return_value.__aenter__.return_value.text.return_value = (
+    mock_session.delete.return_value.__aenter__.return_value.json.return_value = (
         json.dumps({})
     )
     mock_session.delete.return_value.__aenter__.return_value.status = 200
@@ -78,7 +75,7 @@ async def test_applications_delete_success(mock_session):
 @pytest.mark.asyncio
 @patch("aiohttp.ClientSession")
 async def test_applications_create_success(mock_session):
-    mock_session.post.return_value.__aenter__.return_value.text.return_value = (
+    mock_session.post.return_value.__aenter__.return_value.json.return_value = (
         json.dumps(APP_JSON)
     )
     mock_session.post.return_value.__aenter__.return_value.status = 202
@@ -93,5 +90,6 @@ async def test_applications_create_success(mock_session):
     create_response = await Applications(mock_session).create(cap)
 
     assert mock_session.post.call_count == 1
-    assert isinstance(create_response, dict)
-    assert_response_eq(create_response, APP_JSON)
+    assert isinstance(create_response, str)
+
+    assert_response_eq(json.loads(create_response), APP_JSON)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -7,7 +7,6 @@ from tests import assert_response_eq
 from meroxa import CreateResourceParams
 from meroxa import ResourceCredentials
 from meroxa import Resources
-from meroxa.types import ResourceType
 
 RESOURCE_JSON = {
     "id": 9652,
@@ -81,7 +80,7 @@ async def test_resources_create_success(mock_session):
 
     crp = CreateResourceParams(
         name="resource_name",
-        type=ResourceType.POSTGRES.value,
+        type="postgres",
         url="postgres:/connection_url:5432/my_user",
         metadata={"logical_replication": "false"},
         credentials=ResourceCredentials(

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -30,25 +30,7 @@ async def test_user_me_success(mock_session):
 
     mock_session.get.return_value.__aenter__.return_value.status = 200
 
-    _, user_response = await Users(mock_session).me()
+    user_response = await Users(mock_session).me()
 
     assert mock_session.get.call_count == 1
-    assert user_response.__dict__ == USER_RESPONSE_JSON
-
-
-@pytest.mark.asyncio
-@patch("aiohttp.ClientSession")
-async def test_user_me_error(mock_session):
-    mock_session.get.return_value.__aenter__.return_value.text = AsyncMock(
-        return_value=json.dumps(ERROR_MESSAGE)
-    )
-
-    mock_session.get.return_value.__aenter__.return_value.status = 200
-
-    error, user_response = await Users(mock_session).me()
-
-    assert mock_session.get.call_count == 1
-    assert user_response is None
-
-    # TODO: Better comparison logic
-    assert ERROR_MESSAGE.items() <= error.__dict__.items()
+    assert user_response == USER_RESPONSE_JSON

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,8 +1,8 @@
 import json
-from unittest.mock import AsyncMock
 from unittest.mock import patch
 
 import pytest
+from tests import assert_response_eq
 
 from meroxa.users import Users
 
@@ -24,8 +24,8 @@ ERROR_MESSAGE = {"code": "not_found", "message": "could not find user"}
 @pytest.mark.asyncio
 @patch("aiohttp.ClientSession")
 async def test_user_me_success(mock_session):
-    mock_session.get.return_value.__aenter__.return_value.text = AsyncMock(
-        side_effect=[json.dumps(USER_RESPONSE_JSON)]
+    mock_session.get.return_value.__aenter__.return_value.json.return_value = (
+        json.dumps(USER_RESPONSE_JSON)
     )
 
     mock_session.get.return_value.__aenter__.return_value.status = 200
@@ -33,4 +33,4 @@ async def test_user_me_success(mock_session):
     user_response = await Users(mock_session).me()
 
     assert mock_session.get.call_count == 1
-    assert user_response == USER_RESPONSE_JSON
+    assert_response_eq(json.loads(user_response), USER_RESPONSE_JSON)


### PR DESCRIPTION
# Description

**This is a breaking change that needs to be paired with an update in turbine-py** 

`meroxa-py` is not currently resilient to changes in the API response. This is due to the fact that when `meroxa-py` gets a response back from `platform-api` it attempts to deserialize the response into a `Class` with a specific structure. If that class is missing (or expecting) a particular field to be there when it is not (or is)  the json decode will fail and `meroxa-py` will pass an error to `turbine-py`. 

This change will instead pass the JSON directly out and let turbine-py figure out what it would like to do with it. 

### Change summary
- Return `JSON` response bodies instead of ClassObjects 
   - Class methods return one value now as opposed to a tuple of optionals
   - Removed decorators for response formatting
   - Removed Custom response class objects
  

fixes: https://github.com/meroxa/meroxa-py/issues/52


## Type of change

Please delete options that are not relevant.

- [ ] New feature
- [x] Bug fix
- [x] Refactor
- [ ] Documentation

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit Tests
- [x] Manual Tests
- [ ] Deployed to staging

# Additional references

*Any additional links (if appropriate)*
